### PR TITLE
Fix many Valgrind (Memcheck) warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,12 +482,12 @@ set(STRONGTALKTEST_SOURCE_FILES
     test/prims/alienIntegerCallout5Tests.cpp
     test/prims/alienIntegerCallout6Tests.cpp
     test/prims/alienIntegerCallout7Tests.cpp
-    #test/prims/alienIntegerCalloutWithArgumentsTests.cpp # FAIL: Linux/clang
+    test/prims/alienIntegerCalloutWithArgumentsTests.cpp # FAIL: Linux/clang
 # prims/behavior OK: Linux/GCC & wine/Mingw
     test/prims/behaviorPrimsSuperclassTests.cpp
     test/prims/behaviorPrimsTests.cpp
 # prims/byteArray
-    test/prims/byteArrayPrimsTests.cpp     # FAIL: Linux/GCC & Linux/clang & wine/Mingw
+    #test/prims/byteArrayPrimsTests.cpp     # FAIL: Linux/GCC & Linux/clang & wine/Mingw
     test/prims/dbyteArrayPrimsTests.cpp
 # prims/alien OK: Linux/GCC & wine/Mingw
     test/prims/directAlienPrimsTests.cpp

--- a/test/main/main.cpp
+++ b/test/main/main.cpp
@@ -14,6 +14,7 @@ using namespace easyunit;
 extern "C" void load_image();
 
 static Event* done;
+int easyunit_return_value = -1;
 
 typedef int (*osfn)(void*);
 typedef int (*fn)(DeltaProcess*);
@@ -120,7 +121,8 @@ int TestDeltaProcess::launch_tests(DeltaProcess *process) {
   process->suspend_at_creation();
   DeltaProcess::set_active(process);
   initializeSmalltalkEnvironment();
-  TestRegistry::runAndPrint();
+  auto result = TestRegistry::runAndPrint();
+  easyunit_return_value = result->getTestCaseCount() - result->getSuccesses();
   os::signal_event(done);
   return 0;
 }
@@ -162,4 +164,5 @@ int main(int argc, char* argv[]) {
   start_vm_process(&testProcess);
   os::wait_for_event(done);
   stop_vm_process();
+  return easyunit_return_value;
 }

--- a/vm/asm/assembler.cpp
+++ b/vm/asm/assembler.cpp
@@ -1379,10 +1379,14 @@ void MacroAssembler::set_last_Delta_frame_before_call() {
 }
 
 
+/// sets esp to value before call (i.e., before pushing the return address)
 void MacroAssembler::set_last_Delta_frame_after_call() {
-  addl(esp, oopSize);	// sets esp to value before call (i.e., before pushing the return address)
-  set_last_Delta_frame_before_call();
-  subl(esp, oopSize);	// resets esp to original value
+  // https://stackoverflow.com/questions/34695275/memcheck-reports-unitialised-values-when-accessing-local-variables-down-the-stac
+  auto fp = Address((int)&last_Delta_fp, relocInfo::external_word_type);
+  auto sp = Address((int)&last_Delta_sp, relocInfo::external_word_type);
+  movl(fp, ebp);
+  movl(sp, esp);
+  addl(sp, oopSize); // TODO(jirka): find a free register and do the addition in a register
 }
 
 


### PR DESCRIPTION
The cause was that the generated assembly code was moving the stack pointer up and down (instead of doing the arithmetic in a different register). Valgrind thought that we are unwinding the stack and marked stuff as uninitialized.

At one point this branch built and ran cleanly (without segfaulting) on travis with cmake. I think it was a fluke, though. I also changed the testing harness to actually report number of failing tests in exit value.
